### PR TITLE
Allow selection of fixed qp, vbr, cbr or smart when starting v4l2rtsp…

### DIFF
--- a/v4l2rtspserver-master/.gitignore
+++ b/v4l2rtspserver-master/.gitignore
@@ -8,7 +8,10 @@ Makefile
 libv4l2wrapper.a
 h264_v4l2_rtspserver
 v4l2rtspserver
+v4l2rtspserver-master
+_install/
 rootfs
+*.a
 # cpack
 _CPack_Packages
 install_manifest.txt

--- a/v4l2rtspserver-master/inc/ImpEncoder.h
+++ b/v4l2rtspserver-master/inc/ImpEncoder.h
@@ -85,6 +85,7 @@ struct impParams {
     int height;
     int bitrate;
     int framerate;
+    int rcmode;
 };
 struct chn_conf {
     unsigned int index;//0 for main channel ,1 for second channel

--- a/v4l2rtspserver-master/src/ImpEncoder.cpp
+++ b/v4l2rtspserver-master/src/ImpEncoder.cpp
@@ -416,9 +416,26 @@ static void *update_thread(void *p) {
             if (ret < 0) {
                 LOG_S(INFO) << "Unable to get param to change the bitrate";
             }
-            attr.attrH264Smart.maxBitRate = (uint)newConfig->bitrate;
-            attr.attrH264Vbr.maxBitRate = (uint)newConfig->bitrate;
-            attr.attrH264Cbr.outBitRate = (uint)newConfig->bitrate;
+            switch (attr.rcMode) {
+                case ENC_RC_MODE_SMART:
+                    LOG_S(INFO) << "Setting SMART maxBitrate.";
+                    attr.attrH264Smart.maxBitRate = (uint)newConfig->bitrate;
+                    break;
+
+                case ENC_RC_MODE_CBR:
+                    LOG_S(INFO) << "Setting CBR outBitrate.";
+                    attr.attrH264Cbr.outBitRate = (uint)newConfig->bitrate;
+                    break;
+
+                case ENC_RC_MODE_VBR:
+                    LOG_S(INFO) << "Setting VBR maxBitrate.";
+                    attr.attrH264Vbr.maxBitRate = (uint)newConfig->bitrate;
+                    break;
+
+                default:
+                    LOG_S(INFO) << "Bitrate does not apply to rcmode " << attr.rcMode;
+                    break;
+            }
             IMP_Encoder_SetChnAttrRcMode(0, &attr);
             if (ret < 0) {
                 LOG_S(INFO) << "Unable to change the bitrate";

--- a/v4l2rtspserver-master/src/main.cpp
+++ b/v4l2rtspserver-master/src/main.cpp
@@ -288,6 +288,7 @@ int main(int argc, char **argv) {
     int height = 720;
     int queueSize = 10;
     int fps = 25;
+    int rcmode = ENC_RC_MODE_VBR;
     unsigned short rtspPort = 8554;
     unsigned short rtspOverHTTPPort = 0;
     bool multicast = false;
@@ -315,7 +316,7 @@ int main(int argc, char **argv) {
     loguru::set_thread_name("main thread");
     // decode parameters
     int c = 0;
-    while ((c = getopt(argc, argv, "v::Q:O:" "I:P:p:m:u:M:ct:TS::" "R:U:" "nrwsf::F:W:H:" "AC:a:E:" "Vh")) != -1) {
+    while ((c = getopt(argc, argv, "v::Q:O:" "I:P:p:m:u:M:ct:TS::" "R:U:" "nwsf::F:W:H:r:" "AC:a:E:" "Vh")) != -1) {
         switch (c) {
             case 'v':
                 verbose = 1;
@@ -385,7 +386,9 @@ int main(int argc, char **argv) {
             case 'H':
                 height = atoi(optarg);
                 break;
-
+            case 'r':
+                rcmode = atoi(optarg);
+                break;
             case 'A':	disableAudio = true; break;
             case 'E':   decodeEncodeFormat(optarg,encode,outAudioFreq); break;
 
@@ -423,6 +426,7 @@ int main(int argc, char **argv) {
                 std::cout << "\t -W width  : V4L2 capture width (default " << width << ")" << std::endl;
                 std::cout << "\t -H height : V4L2 capture height (default " << height << ")" << std::endl;
                 std::cout << "\t -F fps    : V4L2 capture framerate (default " << fps << ")" << std::endl;
+                std::cout << "\t -r mode   : V4L2 encode mode (0 = FixedQp, 1 = CBR, 2 = VBR, 3 = SMART, default = " << rcmode << ")" << std::endl;
 
                 std::cout << "\t Sound options :" << std::endl;
                 std::cout << "\t -A freq    : Disable Sound"<< std::endl;
@@ -473,6 +477,8 @@ int main(int argc, char **argv) {
         impParams params;
         params.width = width;
         params.height = height;
+        params.rcmode = rcmode;
+        
         if (videoFormat == V4L2_PIX_FMT_MJPEG) {
             params.mode = IMP_MODE_JPEG;
             OutPacketBuffer::maxSize = 250000;


### PR DESCRIPTION
Hi,

I've been looking at the different options for the  `rcMode` when running `sample_encoder_init()`. From the 'carrier sample' they allow vbr/cbr/smart/fixqp.

I've been playing around with the different options, and found the 'smart' setting works best for me, especially when playing with the `qualityLvl` property. But this isn't conclusive, it seems to vary, so I'll keep experimenting.

I was tired of recompiling each time (@EliasKotlyar thanks for making it so easy with the `./compile.sh`!), so I **think** I've managed to allow the selection of this at runtime.

If you pass the `-r` param, you should be able to set the mode.

**I don't know CPP, so this is largely copy/paste and hoping!** It seems to work for me, but any feedback would be appreciated!

If this is accepted, I think a next step would be to set some of the other options via `setconf` (e.g. `qualityLvl`).

Thanks