### PR TITLE
Add build env steps & standardise on git transport

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,19 +3,19 @@
 	url = https://github.com/Dafang-Hacks/v4l2rtspserver-master
 [submodule "mips-gcc472-glibc216-64bit"]
 	path = mips-gcc472-glibc216-64bit
-	url = git@github.com:Dafang-Hacks/mips-gcc472-glibc216-64bit.git
+	url = https://github.com/Dafang-Hacks/mips-gcc472-glibc216-64bit.git
 [submodule "opus"]
 	path = opus
-	url = git@github.com:Dafang-Hacks/opus.git
+	url = https://github.com/Dafang-Hacks/opus.git
 [submodule "live"]
 	path = live
-	url = git@github.com:Dafang-Hacks/live.git
+	url = https://github.com/Dafang-Hacks/live.git
 [submodule "lame"]
 	path = lame
 	url = https://github.com/Dafang-Hacks/lame
 [submodule "drivers"]
 	path = drivers
-	url = git@github.com:Dafang-Hacks/drivers.git
+	url = https://github.com/Dafang-Hacks/drivers.git
 [submodule "kernel"]
 	path = kernel
 	url = https://github.com/Dafang-Hacks/kernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+
+RUN \
+  apt update && apt upgrade -y && \
+  apt install -y \
+  build-essential \
+  git \
+  gcc-mips-linux-gnu \
+  autoconf \
+  libtool \
+  cmake && \
+  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 ### Howto:
 1. Clone this repository using following command: 
-git clone --recurse-submodules git@github.com:Dafang-Hacks/Main.git
+git clone --recurse-submodules https://github.com/Dafang-Hacks/Main.git
 2. Run ./compile-libraries.sh to compile all the required libraries
 3. Go into v4l2rtpsserver-master and use ./compile.sh
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,15 +1,43 @@
 ## Main Repository for Low-Level Development
 
-### Howto:
-1. Clone this repository using following command: 
-git clone --recurse-submodules https://github.com/Dafang-Hacks/Main.git
+### General Howto:
+1. Clone this repository using following command:
+git clone --recurse-submodules git@github.com:Dafang-Hacks/Main.git
 2. Run ./compile-libraries.sh to compile all the required libraries
 3. Go into v4l2rtpsserver-master and use ./compile.sh
 
+### Build Enviroment
+
+#### Ubuntu / Debian (x86 cross-compile)
+Install required dependencies
+
+    $ sudo apt install \
+           build-essential \
+           git \
+           gcc-mips-linux-gnu \
+           autoconf \
+           libtool \
+           cmake
+
+#### Docker env
+ - Use pre-prepared image (by Daviey, https://hub.docker.com/r/daviey/dafang-cross-compile )
+
+       $ mkdir ~/defang
+       $ cd ~/defang
+       $ docker run --rm -ti -v $(pwd):/root/ daviey/dafang-cross-compile:latest
+       $ git clone --recurse-submodules https://github.com/Dafang-Hacks/Main.git
+       $ cd Main
+       $ ./compile.sh
+       (etc)*
+
+ - OR Build local docker image first
+
+        $ git clone --recurse-submodules https://github.com/Dafang-Hacks/Main.git
+        $ cd Main
+        $ docker build -t ${USER}/dafang-cross-compile .
+
 
 ### Sources:
-https://github.com/dim08/Ingenic-T10_20
-
-https://github.com/beihuijie/carrier-rtsp-server
-
-https://github.com/beihuijie/Ingenic-kernel
+- https://github.com/dim08/Ingenic-T10_20
+- https://github.com/beihuijie/carrier-rtsp-server
+- https://github.com/beihuijie/Ingenic-kernel


### PR DESCRIPTION
This change adds 3 main things:
  - Previously there was a mixture of git+ssh and https transports on the submodules, and this makes it harder for non-owners to use, and requires ssh keys with access.  This therefore standardises on https, which anon users can use.
  - Add a Dockerfile with a build env, with the required toolchain and cross compiler for mips.
  - Updated README with instructions on creating a build env (manually and using Docker).

_NOTE: Whilst I have added an automated build to docker hub - I'm more than happy for my one to be dropped and replaced with a Defang managed one._

Thanks 