### PR TITLE
Add u-boot-tools as Ubuntu package requirement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ You can either cross-compile from a native Ubuntu/Debian setup or  build in dock
 Install the required dependencies:
 
 ```shell
-sudo apt install build-essential git gcc-mips-linux-gnu autoconf libtool cmake ftp-upload
+sudo apt install build-essential git gcc-mips-linux-gnu autoconf libtool cmake ftp-upload u-boot-tools
 ```
 
 #### Docker (Slower!)


### PR DESCRIPTION
Building the uImage requires mkimage command, provided by u-boot-tools on Ubuntu