### PR TITLE
busybox: fix issue with cloning https url

### DIFF
--- a/Modules/busybox/compile.sh
+++ b/Modules/busybox/compile.sh
@@ -5,7 +5,7 @@ export LDFLAGS="-muclibc -O3"
 
 if [ ! -d busybox/.git ]
 then
-  git clone http://git.busybox.net/busybox/
+  git clone --depth=1  git://git.busybox.net/busybox
 fi
 
 cd busybox/


### PR DESCRIPTION
Fix infinite hang:
```
$ git clone --verbose http://git.busybox.net/busybox/
Cloning into 'busybox'...
warning: redirecting to https://git.busybox.net/busybox/
<inifinite hang here>
```