### PR TITLE
build mosquitto server, simplified compile.sh

### DIFF
--- a/Modules/dropbear/compile.sh
+++ b/Modules/dropbear/compile.sh
@@ -5,7 +5,7 @@ export LDFLAGS="-muclibc -O3"
 . ../../setCompilePath.sh
 if [ ! -d dropbear ]
 then
-	hg clone https://secure.ucc.asn.au/hg/dropbear
+    git clone https://github.com/mkj/dropbear
 fi
 cp *.h dropbear
 cd dropbear/

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -1,30 +1,22 @@
 #!/usr/bin/env bash
-unset CROSS_COMPILE
-. ../../setCompilePath.sh
-export LIBSSL="${INSTALL}/lib/libtls.a ${INSTALL}/lib/libssl.a ${INSTALL}/lib/libcrypto.a -lpthread"
+ROOTPATH=$(git rev-parse --show-toplevel)
+INSTALL=${ROOTPATH}/_install
+export CROSS_COMPILE=${ROOTPATH}/toolchain
+export CC=/bin/mips-linux-gnu-gcc
+export AR=/bin/mips-linux-gnu-ar
+export CXX=/bin/mips-linux-gnu-g++
+export CFLAGS="-muclibc -O3 -I${INSTALL}/include"
+export CPPFLAGS="-muclibc -O3 -I${INSTALL}/include"
+export LDFLAGS="-muclibc -O3 -lrt -L${INSTALL}/lib -lssl -ltls -lcrypto -lpthread"
 if [ ! -d mosquitto/.git ]
 then
   git clone https://github.com/eclipse/mosquitto.git
-  #Use .a lib instead
-  sed -i 's/\-lssl//' mosquitto/config.mk 
-  sed -i 's/\-lcrypto//' mosquitto/config.mk 
-  LIBSPECIAL=$(echo "$LIBSSL" | sed 's/\//\\\//g')
-  sed -i "s/CLIENT_STATIC_LDADD:=$/CLIENT_STATIC_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/BROKER_LDADD:=$/BROKER_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/CLIENT_LDADD:=$/CLIENT_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/PASSWD_LDADD:=$/PASSWD_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/WITH_STATIC_LIBRARIES:=no/WITH_STATIC_LIBRARIES:=yes/" mosquitto/config.mk
-  sed -i "s/WITH_SHARED_LIBRARIES:=yes/WITH_SHARED_LIBRARIES:=no/" mosquitto/config.mk
-  sed -i "s/WITH_MEMORY_TRACKING:=yes/WITH_MEMORY_TRACKING:=no/" mosquitto/config.mk
-
+  patch mosquitto/config.mk config.diff 
 fi
 
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3 -I${INSTALL}/include -L${INSTALL}/lib "
-export LDFLAGS="-muclibc -O3 -I${INSTALL}/include -L${INSTALL}/lib ${LIBSSL}"
-
 cd mosquitto
-make DESTDIR=$INSTALL
+make
 
 cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
 cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
+cp src/mosquitto ${INSTALL}/bin/mosquitto.bin

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -20,4 +20,5 @@ make
 cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
 cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
 cp src/mosquitto ${INSTALL}/bin/mosquitto.bin
-cp lib/libmosquitto.so ${INSTALL}/lib
+cp lib/libmosquitto.so.1 ${INSTALL}/lib
+cp include/* ${INSTALL}/include

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -20,3 +20,4 @@ make
 cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
 cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
 cp src/mosquitto ${INSTALL}/bin/mosquitto.bin
+cp lib/libmosquitto.so ${INSTALL}/lib

--- a/Modules/mosquitto/config.diff
+++ b/Modules/mosquitto/config.diff
@@ -1,0 +1,60 @@
+diff --git a/config.mk b/config.mk
+index 0d350ec8..ae1cce9d 100644
+--- a/config.mk
++++ b/config.mk
+@@ -29,24 +29,24 @@ WITH_TLS:=yes
+ WITH_TLS_PSK:=yes
+ 
+ # Comment out to disable client threading support.
+-WITH_THREADING:=yes
++#WITH_THREADING:=yes
+ 
+ # Comment out to remove bridge support from the broker. This allow the broker
+ # to connect to other brokers and subscribe/publish to topics. You probably
+ # want to leave this included unless you want to save a very small amount of
+ # memory size and CPU time.
+-WITH_BRIDGE:=yes
++#WITH_BRIDGE:=yes
+ 
+ # Comment out to remove persistent database support from the broker. This
+ # allows the broker to store retained messages and durable subscriptions to a
+ # file periodically and on shutdown. This is usually desirable (and is
+ # suggested by the MQTT spec), but it can be disabled if required.
+-WITH_PERSISTENCE:=yes
++#WITH_PERSISTENCE:=yes
+ 
+ # Comment out to remove memory tracking support from the broker. If disabled,
+ # mosquitto won't track heap memory usage nor export '$SYS/broker/heap/current
+ # size', but will use slightly less memory and CPU time.
+-WITH_MEMORY_TRACKING:=yes
++#WITH_MEMORY_TRACKING:=yes
+ 
+ # Compile with database upgrading support? If disabled, mosquitto won't
+ # automatically upgrade old database versions.
+@@ -55,7 +55,7 @@ WITH_MEMORY_TRACKING:=yes
+ 
+ # Comment out to remove publishing of the $SYS topic hierarchy containing
+ # information about the broker state.
+-WITH_SYS_TREE:=yes
++#WITH_SYS_TREE:=yes
+ 
+ # Build with systemd support. If enabled, mosquitto will notify systemd after
+ # initialization. See README in service/systemd/ for more information.
+@@ -73,7 +73,7 @@ WITH_WEBSOCKETS:=no
+ WITH_EC:=yes
+ 
+ # Build man page documentation by default.
+-WITH_DOCS:=yes
++#WITH_DOCS:=yes
+ 
+ # Build with client support for SOCK5 proxy.
+ WITH_SOCKS:=yes
+@@ -108,7 +108,7 @@ WITH_COVERAGE:=no
+ WITH_UNIX_SOCKETS:=yes
+ 
+ # Build mosquitto_sub with cJSON support
+-WITH_CJSON:=yes
++#WITH_CJSON:=yes
+ 
+ # Build mosquitto with support for the $CONTROL topics.
+ WITH_CONTROL:=yes


### PR DESCRIPTION
This adds the mosquitto server to the build and simplifies the compile.sh script. Note that a `/system/sdcard/bin/mosquitto` script should be added to the camera and that script should `export SNAP_NAME=mosquitto` to fool mosquitto into not trying to `setuid()`.