### PR TITLE
Fix 69 remove system() calls on motion detection/tracking

### DIFF
--- a/Modules/dropbear/compile.sh
+++ b/Modules/dropbear/compile.sh
@@ -5,7 +5,7 @@ export LDFLAGS="-muclibc -O3"
 . ../../setCompilePath.sh
 if [ ! -d dropbear ]
 then
-	hg clone https://secure.ucc.asn.au/hg/dropbear
+    git clone https://github.com/mkj/dropbear
 fi
 cp *.h dropbear
 cd dropbear/

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -1,30 +1,22 @@
 #!/usr/bin/env bash
-unset CROSS_COMPILE
-. ../../setCompilePath.sh
-export LIBSSL="${INSTALL}/lib/libtls.a ${INSTALL}/lib/libssl.a ${INSTALL}/lib/libcrypto.a -lpthread"
+ROOTPATH=$(git rev-parse --show-toplevel)
+INSTALL=${ROOTPATH}/_install
+export CROSS_COMPILE=${ROOTPATH}/toolchain
+export CC=/bin/mips-linux-gnu-gcc
+export AR=/bin/mips-linux-gnu-ar
+export CXX=/bin/mips-linux-gnu-g++
+export CFLAGS="-muclibc -O3 -I${INSTALL}/include"
+export CPPFLAGS="-muclibc -O3 -I${INSTALL}/include"
+export LDFLAGS="-muclibc -O3 -lrt -L${INSTALL}/lib -lssl -ltls -lcrypto -lpthread"
 if [ ! -d mosquitto/.git ]
 then
   git clone https://github.com/eclipse/mosquitto.git
-  #Use .a lib instead
-  sed -i 's/\-lssl//' mosquitto/config.mk 
-  sed -i 's/\-lcrypto//' mosquitto/config.mk 
-  LIBSPECIAL=$(echo "$LIBSSL" | sed 's/\//\\\//g')
-  sed -i "s/CLIENT_STATIC_LDADD:=$/CLIENT_STATIC_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/BROKER_LDADD:=$/BROKER_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/CLIENT_LDADD:=$/CLIENT_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/PASSWD_LDADD:=$/PASSWD_LDADD:=${LIBSPECIAL}/" mosquitto/config.mk
-  sed -i "s/WITH_STATIC_LIBRARIES:=no/WITH_STATIC_LIBRARIES:=yes/" mosquitto/config.mk
-  sed -i "s/WITH_SHARED_LIBRARIES:=yes/WITH_SHARED_LIBRARIES:=no/" mosquitto/config.mk
-  sed -i "s/WITH_MEMORY_TRACKING:=yes/WITH_MEMORY_TRACKING:=no/" mosquitto/config.mk
-
+  patch mosquitto/config.mk config.diff 
 fi
 
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3 -I${INSTALL}/include -L${INSTALL}/lib "
-export LDFLAGS="-muclibc -O3 -I${INSTALL}/include -L${INSTALL}/lib ${LIBSSL}"
-
 cd mosquitto
-make DESTDIR=$INSTALL
+make
 
 cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
 cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
+cp src/mosquitto ${INSTALL}/bin/mosquitto.bin

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -20,4 +20,5 @@ make
 cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
 cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
 cp src/mosquitto ${INSTALL}/bin/mosquitto.bin
-cp lib/libmosquitto.so ${INSTALL}/lib
+cp lib/libmosquitto.so.1 ${INSTALL}/lib
+cp include/* ${INSTALL}/include

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -20,3 +20,4 @@ make
 cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
 cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
 cp src/mosquitto ${INSTALL}/bin/mosquitto.bin
+cp lib/libmosquitto.so ${INSTALL}/lib

--- a/Modules/mosquitto/config.diff
+++ b/Modules/mosquitto/config.diff
@@ -1,0 +1,60 @@
+diff --git a/config.mk b/config.mk
+index 0d350ec8..ae1cce9d 100644
+--- a/config.mk
++++ b/config.mk
+@@ -29,24 +29,24 @@ WITH_TLS:=yes
+ WITH_TLS_PSK:=yes
+ 
+ # Comment out to disable client threading support.
+-WITH_THREADING:=yes
++#WITH_THREADING:=yes
+ 
+ # Comment out to remove bridge support from the broker. This allow the broker
+ # to connect to other brokers and subscribe/publish to topics. You probably
+ # want to leave this included unless you want to save a very small amount of
+ # memory size and CPU time.
+-WITH_BRIDGE:=yes
++#WITH_BRIDGE:=yes
+ 
+ # Comment out to remove persistent database support from the broker. This
+ # allows the broker to store retained messages and durable subscriptions to a
+ # file periodically and on shutdown. This is usually desirable (and is
+ # suggested by the MQTT spec), but it can be disabled if required.
+-WITH_PERSISTENCE:=yes
++#WITH_PERSISTENCE:=yes
+ 
+ # Comment out to remove memory tracking support from the broker. If disabled,
+ # mosquitto won't track heap memory usage nor export '$SYS/broker/heap/current
+ # size', but will use slightly less memory and CPU time.
+-WITH_MEMORY_TRACKING:=yes
++#WITH_MEMORY_TRACKING:=yes
+ 
+ # Compile with database upgrading support? If disabled, mosquitto won't
+ # automatically upgrade old database versions.
+@@ -55,7 +55,7 @@ WITH_MEMORY_TRACKING:=yes
+ 
+ # Comment out to remove publishing of the $SYS topic hierarchy containing
+ # information about the broker state.
+-WITH_SYS_TREE:=yes
++#WITH_SYS_TREE:=yes
+ 
+ # Build with systemd support. If enabled, mosquitto will notify systemd after
+ # initialization. See README in service/systemd/ for more information.
+@@ -73,7 +73,7 @@ WITH_WEBSOCKETS:=no
+ WITH_EC:=yes
+ 
+ # Build man page documentation by default.
+-WITH_DOCS:=yes
++#WITH_DOCS:=yes
+ 
+ # Build with client support for SOCK5 proxy.
+ WITH_SOCKS:=yes
+@@ -108,7 +108,7 @@ WITH_COVERAGE:=no
+ WITH_UNIX_SOCKETS:=yes
+ 
+ # Build mosquitto_sub with cJSON support
+-WITH_CJSON:=yes
++#WITH_CJSON:=yes
+ 
+ # Build mosquitto with support for the $CONTROL topics.
+ WITH_CONTROL:=yes

--- a/v4l2rtspserver-master/compile.sh
+++ b/v4l2rtspserver-master/compile.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
 
-TOOLCHAIN=$(pwd)/../toolchain/bin
+# uncomment to disable the detectionOn/Off/Tracking script execution, instead rely on MQTT
+NO_MOTION_SYSTEM_CALLS="-UMOTION_SYSTEM_CALLS"
+
+ROOTPATH=$(git rev-parse --show-toplevel)
+echo "setting $ROOTPATH"
+export TOOLCHAIN=${ROOTPATH}/toolchain/bin
+CROSS_PREFIX=mips-linux-gnu-
+export CC=${TOOLCHAIN}/${CROSS_PREFIX}gcc
+export LD=${TOOLCHAIN}/${CROSS_PREFIX}ld
+export CCLD=${TOOLCHAIN}/${CROSS_PREFIX}ld
+export CXX=${TOOLCHAIN}/${CROSS_PREFIX}g++
+export CPP=${TOOLCHAIN}/${CROSS_PREFIX}cpp
+export CXXCPP=${TOOLCHAIN}/${CROSS_PREFIX}cpp
+export AR=${TOOLCHAIN}/${CROSS_PREFIX}ar
+export INSTALL=${ROOTPATH}/_install
 export CROSS_COMPILE=$TOOLCHAIN/mips-linux-gnu-
-export CC=${CROSS_COMPILE}gcc
-export LD=${CROSS_COMPILE}g++
-export PKG_CONFIG_PATH="$../_install/lib/pkgconfig"
-export LIBRARY_PATH=../_install/lib
-export CFLAGS="-muclibc -O3 -lrt -I../v4l2rtspserver-tools -I../_install/include/freetype2 -I../../_install/include/"
-export CPPFLAGS="-muclibc -O3 -lrt -I../v4l2rtspserver-tools -I../_install/include/freetype2 -I../../_install/include/ -std=c++11"
-export LDFLAGS="-muclibc -O3 -lrt -lstdc++ -lpthread -ldl"
+export PKG_CONFIG_PATH=$ROOTPATH/_install/lib/pkgconfig
+export LIBRARY_PATH=$ROOTPATH/_install/lib
+export CFLAGS="-muclibc -O3 -lrt -I../v4l2rtspserver-tools -I../_install/include/freetype2 -I../../_install/include/ ${NO_MOTION_SYSTEM_CALLS}"
+export CPPFLAGS="-muclibc -O3 -lrt -I../v4l2rtspserver-tools -I../_install/include/freetype2 -I../../_install/include/ -std=c++11 ${NO_MOTION_SYSTEM_CALLS}"
+export LDFLAGS="-muclibc -O3 -L${LIBRARY_PATH} -lrt -lstdc++ -lpthread -ldl -lmosquitto -lssl -ltls -lcrypto"
 rm CMakeCache.txt
 rm -r CMakeFiles
 cmake -DCMAKE_TOOLCHAIN_FILE="./dafang.toolchain"  -DCMAKE_INSTALL_PREFIX=./_install --debug-output && make VERBOSE=1 -j4 install

--- a/v4l2rtspserver-master/src/ImpEncoder.cpp
+++ b/v4l2rtspserver-master/src/ImpEncoder.cpp
@@ -32,7 +32,11 @@
 #include <stdexcept>
 #include <tuple>
 
+#include <mosquitto.h>
+
 extern "C" {
+struct mosquitto *mosq_cli = NULL;
+
 extern int IMP_OSD_SetPoolSize(int newPoolSize);
 extern int IMP_Encoder_SetPoolSize(int newPoolSize0);
 extern int IMP_OSD_GetPoolSize();
@@ -64,6 +68,32 @@ int motionTimeout = -1; // -1 is for deactivation
 static int ivsMoveStart(int grp_num, int chn_num, IMPIVSInterface **interface, int nbRegions, int val[], int width, int height );
 static void *ivsMoveDetectionThread(void *arg);
 
+extern "C" {
+static void mqtt_pub(char *topic, char *payload) {
+    if (!mosq_cli) return;
+    /* guessing I don't need to include the null terminator of the payload...? */
+    mosquitto_publish(mosq_cli, NULL, topic, strlen(payload), payload, 0, false);
+}
+
+static void mqtt_conn(void) {
+    /* TODO: err msgs */
+    mosq_cli = mosquitto_new(NULL, true, NULL);
+    if(mosq_cli != NULL) {
+        if(mosquitto_connect(mosq_cli, "127.0.0.1", 1883, 30) == MOSQ_ERR_SUCCESS) {
+            mqtt_pub("rtsp/server", "ON");
+            mosq_cli = NULL;
+        }
+    }
+}
+
+static void mqtt_disc(void) {
+    if(mosq_cli != NULL) {
+        mqtt_pub("rtsp/server", "OFF");
+        mosquitto_disconnect(mosq_cli);
+        mosquitto_destroy(mosq_cli);
+    }
+}
+}
 
 static int ivsSetsensitivity(int nbRegion, int sens)
 {
@@ -406,6 +436,7 @@ static int file_exist(const char *filename)
    return 1;
 }
 
+#if MOTION_SYSTEM_CALLS
 static void exec_command(const char *command, char param[4][2])
 {
      if (file_exist(command))
@@ -429,6 +460,9 @@ static void exec_command(const char *command, char param[4][2])
      }
 
 }
+#else /* !MOTION_SYSTEM_CALLS */
+static void exec_command(const char *command, char param[4][2]) { ; /* do nothing */ }
+#endif /* MOTION_SYSTEM_CALLS */
 
 static int ivsMoveStart(int grp_num, int chn_num, IMPIVSInterface **interface, int nbRegions, int val[], int width, int height )
 {
@@ -544,6 +578,7 @@ static void endofmotion(int sig)
 {
     // In case of inactivity execute the script with no arguments
     exec_command(detectionTracking, NULL);
+    mqtt_pub("rtsp/motion/track", "OFF");
     LOG_S(INFO) << "End of motion";
 }
 
@@ -584,6 +619,7 @@ static void *ivsMoveDetectionThread(void *arg)
                    result->retRoi[2] == 1 ||
                    result->retRoi[3] == 1) {
                         char param[4][2] = {};
+                        char mqtt_payload[16];
                         isWasOn[0] = true;
                         gDetectionOn = true;
 
@@ -591,9 +627,12 @@ static void *ivsMoveDetectionThread(void *arg)
                        snprintf(param[1], sizeof(param[1]), "%.1d", result->retRoi[1]);
                        snprintf(param[2], sizeof(param[2]), "%.1d", result->retRoi[2]);
                        snprintf(param[3], sizeof(param[3]), "%.1d", result->retRoi[3]);
+                       snprintf(mqtt_payload, sizeof(mqtt_payload), "%.1d,%.1d,%.1d,%.1d", result->retRoi[0], result->retRoi[1], result->retRoi[2], result->retRoi[3]);
 
                        exec_command(detectionTracking, param);
+                        mqtt_pub("rtsp/motion/track", mqtt_payload);
                        exec_command(detectionScriptOn, NULL);
+                        mqtt_pub("rtsp/motion/detect", "ON");
 
                        if (motionTimeout != -1)
                        {
@@ -605,6 +644,7 @@ static void *ivsMoveDetectionThread(void *arg)
                 {
                     if (isWasOn[0]  == true) {
                         exec_command(detectionScriptOff, NULL);
+                        mqtt_pub("rtsp/motion/detect", "OFF");
                     }
                     gDetectionOn = false;
                     isWasOn[0]  = false;
@@ -626,6 +666,7 @@ static void *ivsMoveDetectionThread(void *arg)
                         {
                             gDetectionOn = true;
                             exec_command(detectionScriptOn, NULL);
+                            mqtt_pub("rtsp/motion/detect", "ON");
                             // Keep on the loop to display logs on the detected area
                         }
                         // Set this flag to avoid executing the detectionOff script on the same loop
@@ -649,6 +690,7 @@ static void *ivsMoveDetectionThread(void *arg)
                     LOG_S(INFO) << "Detect finished on all area !!";
                     gDetectionOn = false;
                     exec_command(detectionScriptOff, NULL);
+                    mqtt_pub("rtsp/motion/detect", "OFF");
                 }
             }
 
@@ -1337,6 +1379,8 @@ int ImpEncoder::system_init()
        }
      */
 
+    mqtt_conn();
+
     return 0;
 }
 
@@ -1346,6 +1390,7 @@ int ImpEncoder::system_exit() {
 
     LOG_S(INFO) << "system_exit start";
 
+    mqtt_disc();
 
     IMP_System_Exit();
 


### PR DESCRIPTION
closes #69 

The detectionOn/Off/Tracking scripts should be re-written to be started as a daemon and watching the MQTT messages. Note that the mosquitto daemon should also be running on the camera for this to work. (v4lrtspserver should still function without the MQTT server, just no motion detection/tracking script execution.)