### PR TITLE
fix #76 - compile cleanups

### DIFF
--- a/Modules/01_libressl/compile.sh
+++ b/Modules/01_libressl/compile.sh
@@ -1,28 +1,19 @@
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+#!/bin/bash
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
-if [ ! -d libressl/.git ]
-then
-  git clone https://github.com/libressl-portable/portable.git
-  git checkout OPENBSD_6_6
-  sed -i 's/program_invocation_short_name/"?"/g' portable/crypto/compat/getprogname_linux.c
+
+if [ ! -d portable/.git ]; then
+    git clone https://github.com/libressl-portable/portable.git
+    cd portable
+#    git checkout OPENBSD_6_6
+    sed -i 's/program_invocation_short_name/"?"/g' crypto/compat/getprogname_linux.c
+    cd ..
 fi
 
-cd portable/
+cd portable
 ./autogen.sh
-./configure --prefix=${INSTALL} --host=mips-linux-gnu --with-pic
+./configure --prefix=${INSTALLDIR} --host=mips-linux-gnu --with-pic
 make -j4
 make install
-
-cp -r */.libs/*.a ${INSTALL}/lib
-cp -rL */.libs/*.la ${INSTALL}/lib
-cp -rL */.libs/*.so ${INSTALL}/lib
-cp --preserve=links */.libs/*.so* ${INSTALL}/lib
-
-cp -r include ${INSTALL}/
-# Compile openssl binary by hand, didn't find how to use static lib instead of dynamic
-export PREF=${INSTALL}
-cd apps/openssl
-${CC} -std=gnu99 ${CFLAGS} -Wall -std=gnu99 -fno-strict-aliasing -fno-strict-overflow -D_FORTIFY_SOURCE=2 -fstack-protector-all -DHAVE_GNU_STACK -Wno-pointer-sign -Wl,-z -Wl,relro -Wl,-z -Wl,now -o openssl.nolib cms.o apps.o asn1pars.o ca.o ciphers.o crl.o crl2p7.o dgst.o dh.o dhparam.o dsa.o dsaparam.o ec.o ecparam.o enc.o errstr.o gendh.o gendsa.o genpkey.o genrsa.o nseq.o ocsp.o openssl.o passwd.o pkcs12.o pkcs7.o pkcs8.o pkey.o pkeyparam.o pkeyutl.o prime.o rand.o req.o rsa.o rsautl.o s_cb.o s_client.o s_server.o s_socket.o s_time.o sess_id.o smime.o speed.o spkac.o ts.o verify.o version.o x509.o certhash.o apps_posix.o compat/strtonum.o ../../ssl/tls13_error.o ${PREF}/lib/libssl.a ${PREF}/lib/libcrypto.a -lpthread -Wl,-rpath -Wl,${PREF}/_install/lib
-cp openssl.nolib ${PREF}/bin/openssl

--- a/Modules/02_libpcre/compile.sh
+++ b/Modules/02_libpcre/compile.sh
@@ -4,9 +4,9 @@ set -e # fail out if any step fails
 
 . ../../setCompilePath.sh
 
-if [ ! -d pcre-8.43/ ]
+if [ ! -d pcre-8.43 ]
 then
-    wget  wget https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
+    wget https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
     tar xvfz pcre-8.43.tar.gz
     rm pcre-8.43.tar.gz
 fi

--- a/Modules/02_libpcre/compile.sh
+++ b/Modules/02_libpcre/compile.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+
+set -e # fail out if any step fails
 
 . ../../setCompilePath.sh
+
 if [ ! -d pcre-8.43/ ]
 then
     wget  wget https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
@@ -12,11 +12,8 @@ then
 fi
 
 cd pcre-8.43
-./configure --host=mips-linux-gnu --prefix=${INSTALL}  --enable-static   --disable-shared --with-gnu-ld
+#./configure --host=mips-linux-gnu --prefix=${INSTALLDIR} --with-gnu-ld
+./configure --host=mips-linux-gnu --prefix=${INSTALLDIR}
 make clean
 make
 make install
-
-cp .libs/*.a ${INSTALL}/lib
-cp pcre-config ${INSTALL}/bin
-cp pcre.h ${INSTALL}/include

--- a/Modules/bftpd/compile.sh
+++ b/Modules/bftpd/compile.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-export CFLAGS="-muclibc"
-export CPPFLAGS="-muclibc -O2"
-export LDFLAGS="-muclibc -O2"
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
+
 if [ ! -d bftpd ]
 then
   wget https://iweb.dl.sourceforge.net/project/bftpd/bftpd/bftpd-5.4/bftpd-5.4.tar.gz
@@ -15,12 +16,11 @@ cat << EOF > bftpd/mypaths.h
 #endif
 #define PATH_STATUSLOG "/dev/null"
 EOF
-
 fi
 
-cd bftpd/
-./configure --host=mips-linux --enable-debug
+cd bftpd
+./configure --host=mips-linux --enable-debug --prefix=${INSTALLDIR}
 make clean
 sed -i "s/LIBS= -lcrypt/LIBS=\${TOOLCHAIN}\/..\/mips-linux-gnu\/libc\/uclibc\/usr\/lib\/libcrypt.a -muclibc/" Makefile
 make
-cp bftpd ${INSTALL}/bin
+cp bftpd ${INSTALLDIR}/bin

--- a/Modules/busybox/compile.sh
+++ b/Modules/busybox/compile.sh
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
+
 if [ ! -d busybox/.git ]
 then
   git clone --depth=1  git://git.busybox.net/busybox
 fi
 
-cd busybox/
+cd busybox
 make clean
 make CROSS_COMPILE=$CROSS_COMPILE defconfig
+
+sleep 1 # ensure timestamp delta
+
 #Remove some packages that doesn't compile
-sed -e 's/CONFIG_FALLOCATE=y/CONFIG_FALLOCATE=n/' -i .config
-sed -e 's/CONFIG_NSENTER=y/CONFIG_NSENTER=n/' -i .config
-sed -e 's/CONFIG_FSYNC=y/CONFIG_FSYNC=n/' -i .config
-sed -e 's/CONFIG_SYNC=y/CONFIG_SYNC=n/' -i .config
-sed -e 's/# CONFIG_FLASH_ERASEALL is not set/CONFIG_FLASH_ERASEALL=y/' -i .config
+sed -i 's/CONFIG_FALLOCATE=y/CONFIG_FALLOCATE=n/' .config
+sed -i 's/CONFIG_NSENTER=y/CONFIG_NSENTER=n/' .config
+sed -i 's/CONFIG_FSYNC=y/CONFIG_FSYNC=n/' .config
+sed -i 's/CONFIG_SYNC=y/CONFIG_SYNC=n/' .config
+sed -i 's/CONFIG_TRACEROUTE=y/CONFIG_TRACEROUTE=n/' .config
+sed -i 's/CONFIG_TRACEROUTE6=y/CONFIG_TRACEROUTE6=n/' .config
+sed -i 's/CONFIG_TRACEROUTE_VERBOSE=y/CONFIG_TRACEROUTE_VERBOSE=n/' .config
+sed -i 's/CONFIG_TRACEROUTE_USE_ICMP=y/CONFIG_TRACEROUTE_USE_ICMP=n/' .config
+sed -i 's/# CONFIG_FLASH_ERASEALL is not set/CONFIG_FLASH_ERASEALL=y/' .config
 make CROSS_COMPILE=$CROSS_COMPILE
 
-cp busybox ${INSTALL}/bin
+cp busybox ${INSTALLDIR}/bin

--- a/Modules/dosfstools/compile.sh
+++ b/Modules/dosfstools/compile.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
+
 if [ ! -d dosfstools/.git ]
 then
   git clone https://github.com/dosfstools/dosfstools
@@ -12,7 +13,7 @@ fi
 cd dosfstools
 autoreconf -i
 ./autogen.sh
-./configure --host=mips-linux --prefix=${INSTALL} --enable-compat-symlinks
+./configure --host=mips-linux --prefix=${INSTALLDIR} --enable-compat-symlinks
 make
 make install
-cp src/fatlabel src/fsck.fat src/mkfs.fat ${INSTALL}/bin 
+cp src/fatlabel src/fsck.fat src/mkfs.fat ${INSTALLDIR}/bin 

--- a/Modules/dosfstools/compile.sh
+++ b/Modules/dosfstools/compile.sh
@@ -11,7 +11,6 @@ fi
 
 
 cd dosfstools
-autoreconf -i
 ./autogen.sh
 ./configure --host=mips-linux --prefix=${INSTALLDIR} --enable-compat-symlinks
 make

--- a/Modules/dropbear/compile.sh
+++ b/Modules/dropbear/compile.sh
@@ -14,8 +14,8 @@ cd dropbear/
 echo '#define DEFAULT_PATH "/usr/bin:/bin:/system/bin:/system/sdcard/bin"' > localoptions.h
 
 autoconf; autoheader
-make clean
 ./configure --host=mips-linux --disable-zlib
+make clean
 make PROGRAMS="dropbear dbclient scp dropbearkey dropbearconvert" MULTI=1 SCPPROGRESS=1
 
 cp dropbearmulti ${INSTALLDIR}/bin

--- a/Modules/dropbear/compile.sh
+++ b/Modules/dropbear/compile.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-export CFLAGS="-muclibc -O3 -DFAKE_ROOT "
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
+
+export CFLAGS="${CFLAGS} -DFAKE_ROOT"
 if [ ! -d dropbear ]
 then
     git clone https://github.com/mkj/dropbear
@@ -16,4 +18,4 @@ make clean
 ./configure --host=mips-linux --disable-zlib
 make PROGRAMS="dropbear dbclient scp dropbearkey dropbearconvert" MULTI=1 SCPPROGRESS=1
 
-cp dropbearmulti ${INSTALL}/bin
+cp dropbearmulti ${INSTALLDIR}/bin

--- a/Modules/dropbear/compile.sh
+++ b/Modules/dropbear/compile.sh
@@ -10,8 +10,8 @@ then
     git clone https://github.com/mkj/dropbear
 fi
 cp *.h dropbear
-cd dropbear/
-echo '#define DEFAULT_PATH "/usr/bin:/bin:/system/bin:/system/sdcard/bin"' > localoptions.h
+cd dropbear
+echo '#define DEFAULT_PATH "/usr/bin:/bin:/system/bin:/system/sdcard/bin"' >> localoptions.h
 
 autoconf; autoheader
 ./configure --host=mips-linux --disable-zlib

--- a/Modules/freetype2/compile.sh
+++ b/Modules/freetype2/compile.sh
@@ -12,9 +12,9 @@ fi
 echo "Compiling freetype"
 
 cd freetype2
-make clean
 ./autogen.sh
 ./configure --host=mips-linux-gnu --without-harfbuzz --without-png --without-zlib --without-bzip2 --prefix=${INSTALLDIR}
+make clean
 make install
 cp objs/.libs/*.a ${INSTALLDIR}/lib
 cp -r include ${INSTALLDIR}

--- a/Modules/freetype2/compile.sh
+++ b/Modules/freetype2/compile.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
+
 if [ ! -d freetype2/.git ]
 then
   git clone git://git.sv.nongnu.org/freetype/freetype2.git
 fi
 
 echo "Compiling freetype"
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
 
 cd freetype2
 make clean
 ./autogen.sh
-./configure --host=mips-linux-gnu --without-harfbuzz --without-png --without-zlib --without-bzip2 --prefix=${INSTALL}
+./configure --host=mips-linux-gnu --without-harfbuzz --without-png --without-zlib --without-bzip2 --prefix=${INSTALLDIR}
 make install
-cp objs/.libs/*.a ${INSTALL}/lib
-cp -r freetype2/include/ ${INSTALL}
+cp objs/.libs/*.a ${INSTALLDIR}/lib
+cp -r include ${INSTALLDIR}

--- a/Modules/lame/compile.sh
+++ b/Modules/lame/compile.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-. ../../setCompilePath.sh
-echo "Using Toolchain $TOOLCHAIN"
+set -e # fail out if any step fails
 
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+. ../../setCompilePath.sh
+
+echo "Using Toolchain $TOOLCHAIN"
 
 if [ ! -d lame-3.100 ]
 then
@@ -15,12 +14,10 @@ then
 fi
 
 cd lame-3.100
+./configure --host=mips-linux-gnu --prefix=${INSTALLDIR}
 make clean
-./configure --host=mips-linux-gnu --prefix=${INSTALL}
-make libmp3lame.so
 make install
 
-cp -r include ${INSTALL}
-cp libmp3lame/.libs/libmp3lame.a ${INSTALL}/lib
-cp mpglib/.libs/libmpgdecoder.a ${INSTALL}/lib
-
+cp -r include ${INSTALLDIR}
+cp libmp3lame/.libs/libmp3lame.a ${INSTALLDIR}/lib
+cp mpglib/.libs/libmpgdecoder.a ${INSTALLDIR}/lib

--- a/Modules/lighttpd1.4/compile.sh
+++ b/Modules/lighttpd1.4/compile.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
-export CFLAGS="-muclibc -O3"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+
+set -e # fail out if any step fails
 
 . ../../setCompilePath.sh
 
-SSLPATH=${INSTALL}
-PCREPATH=${INSTALL}
+SSLPATH=${INSTALLDIR}
+PCREPATH=${INSTALLDIR}
 
 if [ ! -d lighttpd1.4/.git ]
 then
@@ -40,7 +39,6 @@ echo "PLUGIN_INIT(mod_accesslog)" >> src/plugin-static.h
 echo "PLUGIN_INIT(mod_openssl)" >> src/plugin-static.h
 echo "PLUGIN_INIT(mod_setenv)" >> src/plugin-static.h
 echo "PLUGIN_INIT(mod_access)" >> src/plugin-static.h
-echo "PLUGIN_INIT(mod_compress)" >> src/plugin-static.h
 echo "PLUGIN_INIT(mod_deflate)" >> src/plugin-static.h
 echo "PLUGIN_INIT(mod_evasive)" >> src/plugin-static.h 
 echo "PLUGIN_INIT(mod_expire)" >> src/plugin-static.h
@@ -53,4 +51,4 @@ echo "PLUGIN_INIT(mod_usertrack)" >> src/plugin-static.h
 echo "PLUGIN_INIT(mod_vhostdb)" >> src/plugin-static.h
 
 make -j4
-cp src/lighttpd ${INSTALL}/bin/lighttpd.bin
+cp src/lighttpd ${INSTALLDIR}/bin/lighttpd.bin

--- a/Modules/live/compile.sh
+++ b/Modules/live/compile.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+
+set -e # fail out if any step fails
+
 unset  TOOLCHAIN
 . ../../setCompilePath.sh
 
-export LIBSSLL=${INSTALL}
+export LIBSSLL=${INSTALLDIR}
 
 cd live555/
 
@@ -57,9 +60,9 @@ EOF
 ./genMakefiles dafang
 make clean
 make
-cp BasicUsageEnvironment/libBasicUsageEnvironment.so ${INSTALL}/lib
-cp UsageEnvironment/libUsageEnvironment.so ${INSTALL}/lib
-cp groupsock/libgroupsock.so ${INSTALL}/lib
-cp liveMedia/libliveMedia.so ${INSTALL}/lib
+cp BasicUsageEnvironment/libBasicUsageEnvironment.so ${INSTALLDIR}/lib
+cp UsageEnvironment/libUsageEnvironment.so ${INSTALLDIR}/lib
+cp groupsock/libgroupsock.so ${INSTALLDIR}/lib
+cp liveMedia/libliveMedia.so ${INSTALLDIR}/lib
 cd ..
 

--- a/Modules/mdns/compile.sh
+++ b/Modules/mdns/compile.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 
-TOOLCHAIN=$(pwd)/../../toolchain/bin
-INSTALL=$(pwd)/../../_install
-CROSS_COMPILE=$TOOLCHAIN/mips-linux-uclibc-gnu-
-export CROSS_COMPILE=${CROSS_COMPILE}
-export CC=${CROSS_COMPILE}gcc
-export LD=${CROSS_COMPILE}ld
-export STRIP=${CROSS_COMPILE}strip
-export CFLAGS="-muclibc -O3 -std=c99 -DNULL=0 -DTCP_NOTSENT_LOWAT=25"
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+set -e # fail out if any step fails
+
+. ../../setCompilePath.sh
+
+export CFLAGS="${CFLAGS} -std=c99 -DNULL=0 -DTCP_NOTSENT_LOWAT=25"
 
 VERSION="1096.40.7"
 
@@ -23,5 +18,5 @@ fi
 
 cd "mDNSResponder-${VERSION}/mDNSPosix"
 make os=linux clean
-make os=linux HAVE_IPV6=0 CC="$CC" LD="$LD" STRIP="$STRIP" LINKOPTS="-lrt" SAResponder
-cp build/prod/mDNSResponderPosix ${INSTALL}/bin/mDNSResponder
+make os=linux HAVE_IPV6=0 CC="$CC $CFLAGS" LD="$LD" STRIP="$STRIP" LINKOPTS="-lrt" SAResponder
+cp build/prod/mDNSResponderPosix ${INSTALLDIR}/bin/mDNSResponder

--- a/Modules/mosquitto/compile.sh
+++ b/Modules/mosquitto/compile.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-ROOTPATH=$(git rev-parse --show-toplevel)
-INSTALL=${ROOTPATH}/_install
+
+set -e # fail out if any step fails
+
+. ../../setCompilePath.sh
+
 export CROSS_COMPILE=${ROOTPATH}/toolchain
 export CC=/bin/mips-linux-gnu-gcc
 export AR=/bin/mips-linux-gnu-ar
 export CXX=/bin/mips-linux-gnu-g++
-export CFLAGS="-muclibc -O3 -I${INSTALL}/include"
-export CPPFLAGS="-muclibc -O3 -I${INSTALL}/include"
-export LDFLAGS="-muclibc -O3 -lrt -L${INSTALL}/lib -lssl -ltls -lcrypto -lpthread"
+export LDFLAGS="${LDFLAGS} -lrt -lssl -ltls -lcrypto -lpthread"
+
 if [ ! -d mosquitto/.git ]
 then
   git clone https://github.com/eclipse/mosquitto.git
@@ -17,8 +19,9 @@ fi
 cd mosquitto
 make
 
-cp client/mosquitto_sub ${INSTALL}/bin/mosquitto_sub.bin
-cp client/mosquitto_pub ${INSTALL}/bin/mosquitto_pub.bin
-cp src/mosquitto ${INSTALL}/bin/mosquitto.bin
-cp lib/libmosquitto.so.1 ${INSTALL}/lib
-cp include/* ${INSTALL}/include
+cp client/mosquitto_sub ${INSTALLDIR}/bin/mosquitto_sub.bin
+cp client/mosquitto_pub ${INSTALLDIR}/bin/mosquitto_pub.bin
+cp src/mosquitto ${INSTALLDIR}/bin/mosquitto.bin
+cp lib/libmosquitto.so.1 ${INSTALLDIR}/lib
+ln -s ${INSTALLDIR}/lib/libmosquitto.so.1 ${INSTALLDIR}/lib/libmosquitto.so
+cp include/* ${INSTALLDIR}/include

--- a/Modules/opus/compile.sh
+++ b/Modules/opus/compile.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+
+set -e # fail out if any step fails
+
 . ../../setCompilePath.sh
 
-export CFLAGS="-muclibc -O3 -DDEBUG_TRACE -DFAKE_ROOT "
-export CPPFLAGS="-muclibc -O3"
-export LDFLAGS="-muclibc -O3"
+export CFLAGS="${CFLAGS} -DDEBUG_TRACE -DFAKE_ROOT "
 
 if [ ! -d opus-1.3.1 ]
 then
@@ -12,8 +13,7 @@ then
 	rm opus-1.3.1.tar.gz
 fi
 cd opus-1.3.1/
-./autogen.sh
-./configure --host=mips-linux --prefix=${INSTALL}
+./configure --host=mips-linux --prefix=${INSTALLDIR}
 make
-cp --preserve=links -L .libs/lib* ${INSTALL}/lib 
-cp include/* ${INSTALL}/include
+cp --preserve=links -L .libs/lib* ${INSTALLDIR}/lib 
+cp include/* ${INSTALLDIR}/include

--- a/compile_modules.sh
+++ b/compile_modules.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
-export TOOLCHAIN=$(pwd)/toolchain/bin
-export CROSS_COMPILE=$TOOLCHAIN/mips-linux-gnu-
-export CC=${CROSS_COMPILE}gcc
-export LD=${CROSS_COMPILE}ld
-export CCLD=${CROSS_COMPILE}ld
-export CXX=${CROSS_COMPILE}g++
-export CPP=${CROSS_COMPILE}cpp
-export CXXCPP=${CROSS_COMPILE}cpp
-export AR=${CROSS_COMPILE}ar
 
-export INSTALL=$(pwd)/_install
+set -e # fail out if any step fails
+
+. setCompilePath.sh
 
 compile()
 {
@@ -19,10 +12,10 @@ compile()
 	source compile.sh 
 }
 
-mkdir -p ${INSTALL}
-mkdir -p ${INSTALL}/lib
-mkdir -p ${INSTALL}/bin
-mkdir -p ${INSTALL}/include
+mkdir -p ${INSTALLDIR}
+mkdir -p ${INSTALLDIR}/lib
+mkdir -p ${INSTALLDIR}/bin
+mkdir -p ${INSTALLDIR}/include
 export MODULESROOTPATH=$(pwd)
 for module in Modules/* 
 do

--- a/setCompilePath.sh
+++ b/setCompilePath.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 
-if [ -z "$TOOLCHAIN" ]
-then
-	ROOTPATH=$(git rev-parse --show-toplevel)
-	echo "setting $ROOTPATH"
-	cd ${ROOTPATH}
-	export TOOLCHAIN=$(pwd)/toolchain/bin
-	export CROSS_COMPILE=$TOOLCHAIN/mips-linux-gnu-
-	export CC=${CROSS_COMPILE}gcc
-	export LD=${CROSS_COMPILE}ld
-	export CCLD=${CROSS_COMPILE}ld
-	export CXX=${CROSS_COMPILE}g++
-	export CPP=${CROSS_COMPILE}cpp
-	export CXXCPP=${CROSS_COMPILE}cpp
-	export AR=${CROSS_COMPILE}ar
-	export INSTALL=$(pwd)/_install
-	cd -
-fi
+ROOTPATH=$(git rev-parse --show-toplevel)
+echo "setting $ROOTPATH"
+export TOOLCHAIN=${ROOTPATH}/toolchain/bin
+export CROSS_COMPILE=$TOOLCHAIN/mips-linux-gnu-
+export CC=${CROSS_COMPILE}gcc
+export LD=${CROSS_COMPILE}ld
+export CCLD=${CROSS_COMPILE}ld
+export CXX=${CROSS_COMPILE}g++
+export CXXLD=${CROSS_COMPILE}ld
+export CPP=${CROSS_COMPILE}cpp
+export CXXCPP=${CROSS_COMPILE}cpp
+export AR=${CROSS_COMPILE}ar
+export STRIP=${CROSS_COMPILE}strip
+export INSTALLDIR=${ROOTPATH}/_install
+
+export CFLAGS="-muclibc -O3 -I${INSTALLDIR}/include"
+export CPPFLAGS="-muclibc -O3 -I${INSTALLDIR}/include"
+export CXXFLAGS="-muclibc -O3 -I${INSTALLDIR}/include"
+export LDFLAGS="-muclibc -O3 -L${INSTALLDIR}/lib"


### PR DESCRIPTION
Closes #76 

This simplifies the compile scripts and improves them:

* relying on `setCompilePath.sh` for most env vars
* using `$INSTALLDIR` rather than `$INSTALL` (which confuses GNU `libtool`.)
* using `set -e` in all scripts to have them fail if any step fails

Note that busybox no longer has traceroute--it should be added back in when compile issues are resolved.

I am sure there's more improvements that can be made (I am guessing there's still some static linking that is unnecessary, would be good to add "strip" to most everything [maybe have a top-level config whether to build "debug" or "release" versions], relying more on tool-provided `make install` installation, etc.)