### PR TITLE
Update URL to download pcre-8.43.tar.gz

### DIFF
--- a/Modules/02_libpcre/compile.sh
+++ b/Modules/02_libpcre/compile.sh
@@ -6,7 +6,7 @@ set -e # fail out if any step fails
 
 if [ ! -d pcre-8.43 ]
 then
-    wget https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
+    wget https://versaweb.dl.sourceforge.net/project/pcre/pcre/8.43/pcre-8.43.tar.gz
     tar xvfz pcre-8.43.tar.gz
     rm pcre-8.43.tar.gz
 fi


### PR DESCRIPTION
http://pcre.org/ states that "former ftp.pcre.org FTP site is no longer available. You will need to update any scripts that download PCRE source code to download via HTTPS, Git, or Subversion from the new home on GitHub instead." Version 8.43 is available from older Sourceforge repo.