### PR TITLE
ONVIF: Fix Makefile and response with error for unimplemented methods

### DIFF
--- a/onvif/Makefile
+++ b/onvif/Makefile
@@ -208,7 +208,7 @@ packages:
 
 define extract_boost
 	if [ ! -f ./packages/boost_1_72_0.tar.bz2 ]; then \
-		wget -P ./packages https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2; \
+		wget -P ./packages https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2; \
 	fi
 	if [ ! -d $(BOOST_DIR) ]; then \
 		tar xjfv ./packages/boost_1_72_0.tar.bz2 -C $(LIBS_DIR)/; \

--- a/onvif/src/onvif_srvd.c
+++ b/onvif/src/onvif_srvd.c
@@ -324,6 +324,9 @@ int main(int argc, char *argv[])
 		else
 		{
 			DEBUG_MSG("Unknown service\n");
+			soap_stream_fault(soap, std::cerr);
+			soap_send_fault(soap);
+
 		}
 	}
 


### PR DESCRIPTION
Some ONVIF camera viewers do perform some requests to the server that it does not implement, this leads to the ONVIF server not responding, this is eventually resolved by a timeout and a reconnect by the client, this takes a lot of time. This PR fixes this by sending an error message to the client which resolves the problem.

Further, the makefile downloads the boost library, the URL there does not exist no more, I replaced it with a working URL directly from boost.